### PR TITLE
Update rclone to 1.5.2 branch

### DIFF
--- a/support/docker/Dockerfile
+++ b/support/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG RCLONE_VER=1.51
+ARG RCLONE_VER=1.52
 
 FROM golang:alpine AS build-env
 


### PR DESCRIPTION
Consider changing this to `latest` or `1` so it will always use the latest 1.x release.